### PR TITLE
chore: use other way to do tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "postUpgradeTasks": {
-    "commands": [
-      "make clean"
-    ] 
-  }
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
i was fearing this would happen. it looks like it doesn't like the `make clean` option based on the last runs for the new PRs it opened here: https://github.com/go-vela/vela-git/actions?query=is%3Afailure failing on the `validate` option.

had a 50/50 shot and i picked the wrong one hoping it would work.