### PR TITLE
chore(renovate): update golang

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,10 @@
   "labels": [
     "dependencies"
   ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ]
+  "golang": {
+    "postUpdateOptions": [
+      "gomodTidy",
+      "gomodUpdateImportPaths"
+    ]
+  }
 }


### PR DESCRIPTION
updating go-specific options to also include updating import paths for major version updates to avoid some of the issues we've seen with some PRs - see the following for references:
- https://docs.renovatebot.com/configuration-options/#golang
- https://docs.renovatebot.com/configuration-options/#postupdateoptions