### PR TITLE
chore: reduce PR noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,16 @@
     "dependencies"
   ],
   "golang": {
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          "github.com/aws/aws-sdk-go"
+        ],
+        "extends": [
+          "schedule:monthly"
+        ]
+      }
+    ],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"


### PR DESCRIPTION
attempting to reduce some PR noise by putting aws-sdk on a more spaced out schedule. It's even taken directly from the docs (https://docs.renovatebot.com/configuration-options/#schedule):

> This scheduling feature can also be particularly useful for "noisy" packages that are updated frequently, such as aws-sdk.