### PR TITLE
enhance: add oauth2 to monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
     "packageRules": [
       {
         "matchPackageNames": [
-          "github.com/aws/aws-sdk-go"
+          "github.com/aws/aws-sdk-go",
+          "golang.org/x/oauth2"
         ],
         "extends": [
           "schedule:monthly"


### PR DESCRIPTION
we get quite a few golang.org/x/oauth2 PRs (every commit?). this should slow it down a bit.