### PR TITLE
enhance: force semantic commit title

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "labels": [
     "dependencies"
   ],
+  "semanticCommits": "enabled",
   "golang": {
     "packageRules": [
       {


### PR DESCRIPTION
applying https://docs.renovatebot.com/configuration-options/#semanticcommits to force semantic commits. especially on new repos when the previous, default "auto" setting is not able to detect existing commit pattern, it starts off not using semantic commit pattern for PRs.