### PR TITLE
fix(docker-compose): avoid pinning images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,11 @@
         "patch"
       ],
       "groupName": "deps patch"
+    },
+    {
+      "managers": ["docker-compose"],
+      "updateTypes": ["pin", "digest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
docker-compose is intended for local testing/dev and pinning causes unnecessary and undesirable overhead