### PR TITLE
enhance(renovate): add pinDigest to bundled updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,7 @@
         "minor",
         "patch",
         "digest",
+        "pinDigest",
         "pin"
       ],
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
this should help with bundling the `pinDigest` updates with the non-major updates. for example:
- https://github.com/go-vela/vela-downstream/pull/118
- https://github.com/go-vela/vela-downstream/pull/121

could be combined