### PR TITLE
fix(renovate): gomodtidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,6 @@
     "dependencies"
   ],
   "semanticCommits": "enabled",
-  "gomod": {
-    "postUpdateOptions": [
-      "gomodTidy",
-      "gomodUpdateImportPaths"
-    ]
-  },
   "docker-compose": {
     "enabled": false
   },
@@ -58,5 +52,9 @@
       ],
       "enabled": false
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
seeing more and more evidence that go mod tidy isn't actually being run. the docs aren't clear on whether it should be nested or at top-level, but i see more evidence in existing codebases, spec, and issues on renovatebot repo that this should be at the top level. since this is globally applied, not sure how that works with non-golang repos 😨 